### PR TITLE
1301/entity references to core

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -7,7 +7,7 @@
 /**
  * The current system version.
  */
-define('BACKDROP_VERSION', '1.3.4');
+define('BACKDROP_VERSION', '1.3.x-dev');
 
 /**
  * Core API compatibility.

--- a/core/modules/field/modules/reference/README.md
+++ b/core/modules/field/modules/reference/README.md
@@ -1,2 +1,0 @@
-# Reference
-Defines a field type for referencing other entites in Backdrop.


### PR DESCRIPTION
@mikemccaffrey Testing making `PR`'s against your repo for collaborating on `reference` module.

Removing README.md core modules don't have README's.